### PR TITLE
Circleci 2.0へ移行（その2）

### DIFF
--- a/tools/circleci/push-to-master.sh
+++ b/tools/circleci/push-to-master.sh
@@ -20,7 +20,7 @@ fi
 # Get the revision of this branch (master branch)
 REVISION=$(git rev-parse --short HEAD)
 
-mkdir -p ./docs
+mkdir -p ./docs/rust-by-example
 cp -rp ./stage/_book/* ./docs/rust-by-example
 
 (cd ./docs; \


### PR DESCRIPTION
GitHub Pagesへpushするスクリプトに不備があったため、それを修正した。